### PR TITLE
Enable cgo for releases and the build

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -3,8 +3,8 @@ name: Dev release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
-
+      - "v?[0-9]+.[0-9]+.[0-9]+"
+      - "v?[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
 jobs:
   build:
     name: Build project

--- a/wfsm/.goreleaser.dev.yml
+++ b/wfsm/.goreleaser.dev.yml
@@ -1,9 +1,8 @@
 builds:
-  -
-    main: ./cmd/main.go
+  - main: ./cmd/main.go
     binary: wfsm
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     ldflags: "-s -w {{ .Env.GORELEASER_LDFLAGS }}"
     goos:
       - linux
@@ -13,8 +12,7 @@ builds:
       - arm64
 
 archives:
-  -
-    name_template: "wfsm{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - name_template: "wfsm{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: "acpilot_checksums.txt"
@@ -23,8 +21,7 @@ changelog:
   skip: true
 
 nfpms:
-  -
-    vendor: Outshift by Cisco
+  - vendor: Outshift by Cisco
     maintainer: Outshift <outshift@cisco.com>
     homepage: https://cisco.com/
     description: Command-line interface for Agent Workflow Server

--- a/wfsm/.goreleaser.yml
+++ b/wfsm/.goreleaser.yml
@@ -3,7 +3,7 @@ builds:
     main: ./cmd/main.go
     binary: wfsm
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     ldflags: "-s -w {{ .Env.GORELEASER_LDFLAGS }}"
     goos:
       - linux

--- a/wfsm/Makefile
+++ b/wfsm/Makefile
@@ -98,4 +98,7 @@ release-dev: bin/goreleaser # Publish an experimental release
 
 .DEFAULT_GOAL := help
 
+# enable CGO for the project (instrument the build in the included makefile)
+build: export CGO_ENABLED=1
+
 


### PR DESCRIPTION
# Description

Docker compose pulled it dependency on the  fsnotify library; we need cgo enabled because of this

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ x] Existing issues have been referenced (where applicable)
- [ x] I have verified this change is not present in other open pull requests
- [ x] Functionality is documented
- [ x] All code style checks pass
- [ x] New code contribution is covered by automated tests
- [ x] All new and existing tests pass
