### PR TITLE
fix: use docker cli client everywhere

### DIFF
--- a/wfsm/internal/container_client/client.go
+++ b/wfsm/internal/container_client/client.go
@@ -12,7 +12,6 @@ import (
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
-	imagespecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/rs/zerolog"
 )
 
@@ -24,52 +23,16 @@ func CreateBuildContext(path string) (io.ReadCloser, error) {
 	})
 }
 
-func Close(ctx context.Context, client *dockerclient.Client) {
-	log := zerolog.Ctx(ctx)
-
-	if err := client.Close(); err != nil {
-		log.Error().Err(err).Msg("failed to close container_client runtime client")
-	}
-	log.Debug().Msg("closed container_client runtime client")
-}
-
-func CreateContainer(
-	ctx context.Context,
-	client *dockerclient.Client,
-	containerConfig *container.Config,
-	hostConfig *container.HostConfig,
-	platform *imagespecv1.Platform,
-	containerName string) (string, error) {
-	log := zerolog.Ctx(ctx).With().Str("container_name", containerName).Logger()
-
-	createResp, err := client.ContainerCreate(
-		ctx, containerConfig,
-		hostConfig,
-		nil,
-		platform,
-		containerName)
-	if err != nil {
-		return "", fmt.Errorf("failed to create container_client: %w", err)
-	}
-
-	if len(createResp.Warnings) == 0 {
-		log.Debug().Msg("created container_client")
-	} else {
-		log.Warn().Strs("warnings", createResp.Warnings).Msg("created container_client with warnings")
-	}
-	return createResp.ID, nil
-}
-
 // if the container is running, return the public port or 0 otherwise
 func IsContainerRunning(
 	ctx context.Context,
-	client *dockerclient.Client,
+	cntClient dockerclient.ContainerAPIClient,
 	image string,
 	containerName string) (int, error) {
 
 	log := zerolog.Ctx(ctx).With().Str("container_name", containerName).Logger()
 
-	cList, err := client.ContainerList(ctx, container.ListOptions{
+	cList, err := cntClient.ContainerList(ctx, container.ListOptions{
 		All: true,
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "name",
@@ -105,51 +68,4 @@ func getPublicPort(ports []container.Port) int {
 		}
 	}
 	return 0
-}
-
-func RemoveContainer(ctx context.Context, client *dockerclient.Client, containerID string) error {
-	log := zerolog.Ctx(ctx)
-
-	err := client.ContainerRemove(ctx, containerID, container.RemoveOptions{RemoveVolumes: true})
-	if err != nil {
-		return err
-	}
-	log.Debug().Msg("removed container_client")
-	return nil
-}
-
-func StartContainer(
-	ctx context.Context,
-	client *dockerclient.Client,
-	containerID string) error {
-	log := zerolog.Ctx(ctx)
-
-	err := client.ContainerStart(ctx, containerID, container.StartOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to start container_client: %w", err)
-	}
-	log.Debug().Msg("started container_client")
-
-	return nil
-}
-
-func CopyToContainer(ctx context.Context, client *dockerclient.Client, containerID, src, dst string) error {
-	log := zerolog.Ctx(ctx)
-
-	appSrc, err := archive.Tar(src, archive.Uncompressed)
-	if err != nil {
-		return fmt.Errorf("failed to tar source dir: %w", err)
-	}
-	defer func() {
-		if err = appSrc.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close archived source reader")
-		}
-	}()
-
-	err = client.CopyToContainer(ctx, containerID, dst, appSrc, container.CopyToContainerOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to archive to container_client: %w", err)
-	}
-
-	return nil
 }

--- a/wfsm/internal/platforms/docker_compose/runner.go
+++ b/wfsm/internal/platforms/docker_compose/runner.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/cisco-eti/wfsm/internal"
+	"github.com/cisco-eti/wfsm/internal/util"
 	"github.com/docker/compose/v2/cmd/formatter"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/compose"
@@ -28,7 +29,7 @@ func NewDockerComposeRunner(hostStorageFolder string) internal.AgentDeploymentRu
 }
 
 func (r *runner) Remove(ctx context.Context, deploymentName string) error {
-	dockerCli, err := getDockerCLI(ctx)
+	dockerCli, err := util.GetDockerCLI(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to initialize docker client: %v", err)
 	}
@@ -47,7 +48,7 @@ func (r *runner) Remove(ctx context.Context, deploymentName string) error {
 }
 
 func (r *runner) Logs(ctx context.Context, deploymentName string, agentNames []string) error {
-	dockerCli, err := getDockerCLI(ctx)
+	dockerCli, err := util.GetDockerCLI(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to initialize docker client: %v", err)
 	}
@@ -71,7 +72,7 @@ func (r *runner) Logs(ctx context.Context, deploymentName string, agentNames []s
 func (r *runner) List(ctx context.Context, deploymentName string) error {
 	log := zerolog.Ctx(ctx)
 
-	dockerCli, err := getDockerCLI(ctx)
+	dockerCli, err := util.GetDockerCLI(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to initialize docker client: %v", err)
 	}

--- a/wfsm/internal/util/util.go
+++ b/wfsm/internal/util/util.go
@@ -3,10 +3,14 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os/user"
 	"runtime"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/flags"
 )
 
 const OwnerCanReadWrite = 0777
@@ -38,4 +42,18 @@ func GetHomeDir() (string, error) {
 		return "", fmt.Errorf("failed to get current user: %w", err)
 	}
 	return usr.HomeDir, nil
+}
+
+func GetDockerCLI(ctx context.Context) (*command.DockerCli, error) {
+	dockerCli, err := command.NewDockerCli(command.WithBaseContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create docker cli: %v", err)
+	}
+	clientOptions := flags.ClientOptions{
+		LogLevel:  "debug",
+		TLS:       false,
+		TLSVerify: false,
+	}
+	err = dockerCli.Initialize(&clientOptions)
+	return dockerCli, err
 }


### PR DESCRIPTION
# Description

Use docker CLI client everywhere, to make sure the right docker context is used.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
