### PR TITLE
Support for relative paths in agent manifests

### DIFF
--- a/wfsm/go.mod
+++ b/wfsm/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
-	github.com/fatih/color v1.15.0 // indirect
+	github.com/fatih/color v1.17.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsevents v0.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
@@ -161,6 +161,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+	github.com/miekg/dns v1.1.63 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/wfsm/go.sum
+++ b/wfsm/go.sum
@@ -872,8 +872,8 @@ github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
-github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
+github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
+github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -1215,8 +1215,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
-github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
+github.com/miekg/dns v1.1.63 h1:8M5aAw6OMZfFXTT7K5V0Eu5YiiL8l7nUAkyN6C9YwaY=
+github.com/miekg/dns v1.1.63/go.mod h1:6NGHfjhpmr5lt3XPLuyfDJi5AXbNIPM9PY6H6sF1Nfs=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
 github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/wfsm/internal/builder/python/builder.go
+++ b/wfsm/internal/builder/python/builder.go
@@ -36,7 +36,7 @@ func (b *pyBuilder) Build(ctx context.Context, inputSpec internal.AgentSpec) (in
 	deploymentSpec := internal.AgentDeploymentBuildSpec{AgentSpec: inputSpec}
 
 	deployment := inputSpec.Manifest.Deployment.DeploymentOptions[inputSpec.SelectedDeploymentOption]
-	agSrc, err := source.GetAgentSource(deployment.SourceCodeDeployment)
+	agSrc, err := source.GetAgentSource(deployment.SourceCodeDeployment, inputSpec.ManifestPath)
 	if err != nil {
 		return deploymentSpec, fmt.Errorf("failed to get agent source: %v", err)
 	}

--- a/wfsm/internal/builder/python/source/agent.go
+++ b/wfsm/internal/builder/python/source/agent.go
@@ -5,7 +5,7 @@ package source
 import (
 	"fmt"
 	"net/url"
-	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/cisco-eti/wfsm/manifests"
@@ -16,7 +16,7 @@ type AgentSource interface {
 	CopyToWorkspace(workspacePath string) error
 }
 
-func GetAgentSource(deployment *manifests.SourceCodeDeployment) (AgentSource, error) {
+func GetAgentSource(deployment *manifests.SourceCodeDeployment, manifestPath string) (AgentSource, error) {
 	parsedURL, err := url.Parse(deployment.Url)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,8 @@ func GetAgentSource(deployment *manifests.SourceCodeDeployment) (AgentSource, er
 		}
 		if isLocalPath(deployment.Url) && !isZipOrTarball(deployment.Url) {
 			return &LocalSource{
-				LocalPath: deployment.Url,
+				ManifestPath: manifestPath,
+				LocalPath:    deployment.Url,
 			}, nil
 		}
 		return &GoGetSource{
@@ -45,8 +46,10 @@ func GetAgentSource(deployment *manifests.SourceCodeDeployment) (AgentSource, er
 			}, nil
 		}
 		if isLocalPath(deploymentUrl) {
+
 			return &LocalSource{
-				LocalPath: deploymentUrl,
+				ManifestPath: manifestPath,
+				LocalPath:    deploymentUrl,
 			}, nil
 		}
 
@@ -61,6 +64,7 @@ func isZipOrTarball(url string) bool {
 
 func isLocalPath(url string) bool {
 	// Implement logic to check if the URL is a local path
-	_, err := os.Stat(url)
-	return err == nil
+	//_, err := os.Stat(url)
+
+	return filepath.IsLocal(url) || filepath.IsAbs(url) || strings.HasPrefix(url, ".") || strings.HasPrefix(url, "..")
 }

--- a/wfsm/internal/builder/python/source/local_test.go
+++ b/wfsm/internal/builder/python/source/local_test.go
@@ -1,0 +1,69 @@
+package source
+
+import (
+	"testing"
+)
+
+func TestLocalSource_ResolveSourcePath(t *testing.T) {
+	type fields struct {
+		LocalPath    string
+		ManifetsPath string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "Local path is empty",
+			fields: fields{
+				LocalPath:    "",
+				ManifetsPath: "/Users/lpuskas/prj/cisco-eti/agent-workflow-cli/examples/manifest.json",
+			},
+			want: "/Users/lpuskas/prj/cisco-eti/agent-workflow-cli/examples",
+		},
+		{
+			name: "Manifest path is empty",
+			fields: fields{
+				LocalPath:    "../../elements/agent",
+				ManifetsPath: "",
+			},
+			want: "../../elements/agent",
+		},
+		{
+			name: "Local path is one level up",
+			fields: fields{
+				LocalPath:    "../elements/agent",
+				ManifetsPath: "/Users/lpuskas/prj/cisco-eti/agent-workflow-cli/examples/manifest.json",
+			},
+			want: "/Users/lpuskas/prj/cisco-eti/agent-workflow-cli/elements/agent",
+		},
+		{
+			name: "Local path is two levels up",
+			fields: fields{
+				LocalPath:    "../../elements/agent",
+				ManifetsPath: "/Users/lpuskas/prj/cisco-eti/agent-workflow-cli/examples/manifest.json",
+			},
+			want: "/Users/lpuskas/prj/cisco-eti/elements/agent",
+		},
+		{
+			name: "Local path is absolute",
+			fields: fields{
+				LocalPath:    "/elements/agent",
+				ManifetsPath: "/Users/lpuskas/prj/cisco-eti/agent-workflow-cli/examples/manifest.json",
+			},
+			want: "/elements/agent",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ls := &LocalSource{
+				LocalPath:    tt.fields.LocalPath,
+				ManifestPath: tt.fields.ManifetsPath,
+			}
+			if got := ls.ResolveSourcePath(); got != tt.want {
+				t.Errorf("ResolveSourcePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/wfsm/internal/types.go
+++ b/wfsm/internal/types.go
@@ -22,6 +22,7 @@ type AgentSpec struct {
 	ApiKey                   string
 	Port                     int
 	K8sConfig                K8sConfig
+	ManifestPath             string
 }
 type K8sConfig struct {
 	EnvVarsFromSecret string      `yaml:"envVarsFromSecret"`

--- a/wfsm/internal/wfsm/command/deploy.go
+++ b/wfsm/internal/wfsm/command/deploy.go
@@ -9,10 +9,11 @@ import (
 	"os"
 	"path"
 
-	"github.com/cisco-eti/wfsm/internal/platforms"
-	"github.com/cisco-eti/wfsm/internal/wfsm/config"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
+
+	"github.com/cisco-eti/wfsm/internal/platforms"
+	"github.com/cisco-eti/wfsm/internal/wfsm/config"
 
 	"github.com/cisco-eti/wfsm/internal"
 	"github.com/cisco-eti/wfsm/internal/builder"

--- a/wfsm/internal/wfsm/manifest/test/manifest_2/agent_A_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_2/agent_A_manifest.json
@@ -45,7 +45,7 @@
         "ref": {
           "name": "agent_B",
           "version": "1.0.0",
-          "url": "test/manifest_2/agent_B_manifest.json"
+          "url": "agent_B_manifest.json"
         },
         "deployment_option": "src",
         "env_var_values": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_2/agent_B_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_2/agent_B_manifest.json
@@ -45,7 +45,7 @@
         "ref": {
           "name": "agent_C",
           "version": "1.0.0",
-          "url": "test/manifest_2/agent_C_manifest.json"
+          "url": "agent_C_manifest.json"
         },
         "deployment_option": "src",
         "env_var_values": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_3/agent_A_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_3/agent_A_manifest.json
@@ -45,7 +45,7 @@
         "ref": {
           "name": "agent_B",
           "version": "1.0.0",
-          "url": "test/manifest_3/agent_B_manifest.json"
+          "url": "agent_B_manifest.json"
         },
         "deployment_option": "src",
         "env_var_values": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_3/agent_B_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_3/agent_B_manifest.json
@@ -45,7 +45,7 @@
         "ref": {
           "name": "agent_C",
           "version": "1.0.0",
-          "url": "test/manifest_3/agent_C_manifest.json"
+          "url": "agent_C_manifest.json"
         },
         "deployment_option": "src",
         "env_var_values": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_4/agent_A_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_4/agent_A_manifest.json
@@ -45,7 +45,7 @@
         "ref": {
           "name": "agent_B",
           "version": "1.0.0",
-          "url": "test/manifest_4/agent_B_manifest.json"
+          "url": "agent_B_manifest.json"
         },
         "deployment_option": "src",
         "env_var_values": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_4/agent_B_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_4/agent_B_manifest.json
@@ -45,7 +45,7 @@
         "ref": {
           "name": "agent_C",
           "version": "1.0.0",
-          "url": "test/manifest_4/agent_C_manifest.json"
+          "url": "agent_C_manifest.json"
         },
         "deployment_option": "src",
         "env_var_values": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_4/agent_C_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_4/agent_C_manifest.json
@@ -45,7 +45,7 @@
           "ref": {
             "name": "agent_C",
             "version": "1.0.0",
-            "url": "test/manifest_4/agent_C_manifest.json"
+            "url": "agent_C_manifest.json"
           },
           "deployment_option": "src",
           "env_var_values": {


### PR DESCRIPTION
# Description

Agent manifests may dependencies declared relative to the manifest file itself - in case of local / file references.

When reading dependent manifests, location is normalized based on the manifest the dependencies are declared.


## Type of Change

- [ ] Bugfix
- [ x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ x] Existing issues have been referenced (where applicable)
- [ x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ x] All new and existing tests pass
