### PR TITLE
feat: add support for llamaindex interrupts

### DIFF
--- a/wfsm/spec/manifest.yaml
+++ b/wfsm/spec/manifest.yaml
@@ -79,14 +79,13 @@ components:
           description: >-
             Reference to the agent in the agent directory. It includes the
             version and the locator.
-          $ref: './acp-spec/openapi.yaml#/components/schemas/AgentRef'
+          $ref: './acp-spec/openapi.json#/components/schemas/AgentRef'
         deployment_option:
           description: >-
             Selected deployment option for this agent. 
           title: Deployment Option
           type: string
         env_var_values:
-          title: Environment Variable Values
           description: Environment variable values to be set for this agent.
           $ref: '#/components/schemas/EnvVarValues'
       required:
@@ -193,6 +192,10 @@ components:
             - llamaindex
         path:
           type: string
+        interrupts:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/InterruptConfig'
       required:
         - framework_type
         - path
@@ -267,6 +270,18 @@ components:
       required:
         - type
         - url
+    InterruptConfig:
+      type: object
+      properties:
+        interrupt_ref:
+          type: string
+          example: my_app.interrupts:InterruptEvent
+        resume_ref:
+          type: string
+          example: my_app.interrupts:ResponseEvent
+      required:
+        - interrupt_ref
+        - resume_ref
     SecurityScheme:
       type: object
       description: >-


### PR DESCRIPTION
# Description

See https://github.com/agntcy/workflow-srv/pull/70

This is needed to bind interrupt_types in https://github.com/agntcy/acp-spec/blob/main/openapi.json#L2092 with the respective python objects (Event classes for interrupts).

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
