### PR TITLE
fix: update OASF extension name for manifests

### DIFF
--- a/examples/langgraph_manifest.json
+++ b/examples/langgraph_manifest.json
@@ -20,7 +20,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "data": {
         "deployment": {
           "agent_deps": [],

--- a/examples/llama_manifest.json
+++ b/examples/llama_manifest.json
@@ -20,7 +20,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "data": {
         "acp": {
           "capabilities": {

--- a/examples/manifest_with_deps.json
+++ b/examples/manifest_with_deps.json
@@ -20,7 +20,7 @@
   ],  
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v0.0.1",
       "data": {
         "acp": {

--- a/wfsm/internal/platforms/docker/deployer_test.go
+++ b/wfsm/internal/platforms/docker/deployer_test.go
@@ -31,7 +31,7 @@ func TestRunner_Deploy_DryRun(t *testing.T) {
 				Manifest: manifests.AgentManifest{
 					Extensions: []manifests.Manifest{
 						{
-							Name:    "oasf.agntcy.org/feature/runtime/manifest",
+							Name:    "schema.oasf.agntcy.org/features/runtime/manifest",
 							Version: &version,
 							Data: manifests.DeploymentManifest{
 								Deployment: manifests.AgentDeployment{
@@ -66,7 +66,7 @@ func TestRunner_Deploy_DryRun(t *testing.T) {
 				Manifest: manifests.AgentManifest{
 					Extensions: []manifests.Manifest{
 						{
-							Name:    "oasf.agntcy.org/feature/runtime/manifest",
+							Name:    "schema.oasf.agntcy.org/features/runtime/manifest",
 							Version: &version,
 							Data: manifests.DeploymentManifest{
 								Deployment: manifests.AgentDeployment{

--- a/wfsm/internal/wfsm/manifest/manifest.go
+++ b/wfsm/internal/wfsm/manifest/manifest.go
@@ -51,7 +51,7 @@ func (m manifestService) Validate() error {
 		return errors.New("invalid agent manifest: no deployment extensions found in manifest")
 	}
 	if !depoloymentExtensionIsPresent(m.manifest) {
-		return errors.New("invalid agent manifest: no deployment extension 'oasf.agntcy.org/feature/runtime/manifest' found in manifest")
+		return errors.New("invalid agent manifest: no deployment extension 'schema.oasf.agntcy.org/features/runtime/manifest' found in manifest")
 	}
 	return m.ValidateDeploymentOptions()
 }
@@ -86,7 +86,7 @@ func (m manifestService) GetDeploymentOptionIdx(option *string) (int, error) {
 
 func depoloymentExtensionIsPresent(manifest manifests.AgentManifest) bool {
 	for _, ext := range manifest.Extensions {
-		if ext.Name == "oasf.agntcy.org/feature/runtime/manifest" {
+		if ext.Name == "schema.oasf.agntcy.org/features/runtime/manifest" {
 			return true
 		}
 	}
@@ -95,7 +95,7 @@ func depoloymentExtensionIsPresent(manifest manifests.AgentManifest) bool {
 
 func GetDeployment(manifest manifests.AgentManifest) manifests.AgentDeployment {
 	for _, ext := range manifest.Extensions {
-		if ext.Name == "oasf.agntcy.org/feature/runtime/manifest" {
+		if ext.Name == "schema.oasf.agntcy.org/features/runtime/manifest" {
 			return ext.Data.Deployment
 		}
 	}

--- a/wfsm/internal/wfsm/manifest/manifest_loader.go
+++ b/wfsm/internal/wfsm/manifest/manifest_loader.go
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-const AgentExtensionName = "oasf.agntcy.org/feature/runtime/manifest"
+const AgentExtensionName = "schema.oasf.agntcy.org/features/runtime/manifest"
 
 type fileManifestLoader struct {
 	filePath string

--- a/wfsm/internal/wfsm/manifest/test/manifest_1/manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_1/manifest.json
@@ -54,7 +54,7 @@
       }
     },
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v0.0.1",
       "data": {
         "acp": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_1/manifest_with_err.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_1/manifest_with_err.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest23",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest23",
       "version": "v0.0.1",
       "data": {
         "acp": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_2/agent_A_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_2/agent_A_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_2/agent_B_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_2/agent_B_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_2/agent_C_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_2/agent_C_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_3/agent_A_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_3/agent_A_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_3/agent_B_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_3/agent_B_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_3/agent_C_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_3/agent_C_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_4/agent_A_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_4/agent_A_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_4/agent_B_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_4/agent_B_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {

--- a/wfsm/internal/wfsm/manifest/test/manifest_4/agent_C_manifest.json
+++ b/wfsm/internal/wfsm/manifest/test/manifest_4/agent_C_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {

--- a/wfsm/spec/examples/agentA_manifest.json
+++ b/wfsm/spec/examples/agentA_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {

--- a/wfsm/spec/examples/agentB_manifest.json
+++ b/wfsm/spec/examples/agentB_manifest.json
@@ -19,7 +19,7 @@
   ],
   "extensions": [
     {
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "version": "v1.0.0",
       "data": {
         "acp": {


### PR DESCRIPTION
# Description

This PR updates the string used for OASF manifest extension to the one published in the OASF: `schema.oasf.agntcy.org/features/runtime/manifest`

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
